### PR TITLE
eigen: unbreak macOS ppc build

### DIFF
--- a/external_libs/eigen/Eigen/Core
+++ b/external_libs/eigen/Eigen/Core
@@ -199,7 +199,7 @@ using std::ptrdiff_t;
   #include "src/Core/arch/SSE/TypeCasting.h"
   #include "src/Core/arch/SSE/MathFunctions.h"
   #include "src/Core/arch/SSE/Complex.h"
-#elif defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX)
+#elif (defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX)) && !defined(__APPLE__)
   #include "src/Core/arch/AltiVec/PacketMath.h"
   #include "src/Core/arch/AltiVec/MathFunctions.h"
   #include "src/Core/arch/AltiVec/Complex.h"
@@ -339,7 +339,7 @@ using std::ptrdiff_t;
 #include "src/Core/CoreIterators.h"
 #include "src/Core/ConditionEstimator.h"
 
-#if defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX)
+#if (defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX)) && !defined(__APPLE__)
   #include "src/Core/arch/AltiVec/MatrixProduct.h"
 #elif defined EIGEN_VECTORIZE_NEON
   #include "src/Core/arch/NEON/GeneralBlockPanelKernel.h"


### PR DESCRIPTION
As I have mentioned earlier, macOS ppc needs a fix for Eigen headers. This has been fixed in upstream in https://gitlab.com/libeigen/eigen/-/commit/4d05765345e7e4a984d600039f797e2fede924f3
However, older versions of Eigen apparently miss some other needed fixes, so a trivial backport of defines does not work (not just here, it fails for us in Macports too).
Therefore, disable vectorization on macOS ppc and fix the build.