### PR TITLE
Fix naming conflict between Realloc (from RS.h) and Windows headers.

### DIFF
--- a/R-package/src/gpboost_R.cpp
+++ b/R-package/src/gpboost_R.cpp
@@ -13,6 +13,7 @@
 
 #include <R_ext/Rdynload.h>
 
+#define STRICT_R_HEADERS
 #define R_NO_REMAP
 #define R_USE_C99_IN_CXX
 #include <R_ext/Error.h>

--- a/R-package/src/gpboost_R.h
+++ b/R-package/src/gpboost_R.h
@@ -8,6 +8,7 @@
 
 #include <LightGBM/c_api.h>
 
+#define STRICT_R_HEADERS
 #define R_NO_REMAP
 #define R_USE_C99_IN_CXX
 #include <Rinternals.h>

--- a/include/LightGBM/utils/log.h
+++ b/include/LightGBM/utils/log.h
@@ -16,6 +16,7 @@
 #include <string>
 
 #ifdef LGB_R_BUILD
+#define STRICT_R_HEADERS
 #define R_NO_REMAP
 #define R_USE_C99_IN_CXX
 #include <R_ext/Error.h>


### PR DESCRIPTION
This fixes the package to build on Windows with R-devel. As can be seen in the CRAN check results for the package, there is a naming conflict on symbol Realloc, which is a legacy macro in RS.h (for S compatibility), but also is used in Windows headers. The conflict could be resolved by including Windows (system, library) headers before R headers, but the includes in gpboost are not organized that way.

The patch instead fixes this by disabling the S compatibility layer.

Excerpt from the error log:
```
In file included from D:/rtools44/x86_64-w64-mingw32.static.posix/include/combaseapi.h:155,
                 from D:/rtools44/x86_64-w64-mingw32.static.posix/include/objbase.h:14,
                 from D:/rtools44/x86_64-w64-mingw32.static.posix/include/ole2.h:17,
                 from D:/rtools44/x86_64-w64-mingw32.static.posix/include/wtypes.h:13,
                 from D:/rtools44/x86_64-w64-mingw32.static.posix/include/winscard.h:10,
                 from D:/rtools44/x86_64-w64-mingw32.static.posix/include/windows.h:97,
                 from D:/rtools44/x86_64-w64-mingw32.static.posix/include/winsock2.h:23,
                 from network/socket_wrapper.hpp:22,
                 from network/linkers.h:22,
                 from network/linkers_socket.cpp:20:
D:/rtools44/x86_64-w64-mingw32.static.posix/include/objidlbase.h:1065:18: error: macro "Realloc" requires 3 arguments, but only 2 given
 1065 |         SIZE_T cb) = 0;
      |                  ^
In file included from D:/RCompile/recent/R/include/R_ext/Error.h:30,
                 from ./include/LightGBM/utils/log.h:21,
                 from ./include/LightGBM/utils/common.h:12,
                 from ./include/LightGBM/config.h:23,
                 from network/linkers_socket.cpp:7:
D:/RCompile/recent/R/include/R_ext/RS.h:57: note: macro "Realloc" defined here
   57 | #define Realloc(p,n,t) (t *) R_chk_realloc( (void *)(p), (R_SIZE_T)((n) * sizeof(t)) )
```