### PR TITLE
Implemented method `GPBoostModel.__sklearn_tags__()` to comply with `sklearn=1.6.1`.

### DIFF
--- a/python-package/gpboost/sklearn.py
+++ b/python-package/gpboost/sklearn.py
@@ -826,6 +826,10 @@ class GPBoostModel(_GPBoostModelBase):
             raise GPBoostNotFittedError('No feature_name found. Need to call fit beforehand.')
         return self._Booster.feature_name()
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        return tags
+
 
 class GPBoostRegressor(GPBoostModel, _GPBoostRegressorBase):
     """GPBoost regressor."""


### PR DESCRIPTION
Fixes #152. The only change is to create a method which resolves an error in compatibility with `scikit-learn=1.6.1`. This method shouldn't make a difference if using previous versions as it just won't get run in that case.
